### PR TITLE
Fix Android TV detection logic

### DIFF
--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -1,5 +1,9 @@
 export function detectDeviceType(): 'tv' | 'mobile' | 'desktop' {
   const ua = navigator.userAgent.toLowerCase();
+
+  const isAndroid = ua.includes('android');
+  const hasMobileToken = /mobile|mobi|touch|mini|windows ce|palm/i.test(ua);
+
   if (
     ua.includes('smart-tv') ||
     ua.includes('smarttv') ||
@@ -16,12 +20,15 @@ export function detectDeviceType(): 'tv' | 'mobile' | 'desktop' {
     ua.includes('dtv') ||
     ua.includes('sonydtv') ||
     ua.includes('hisense') ||
-    (ua.includes('tv') && !ua.includes('mobile'))
+    (ua.includes('tv') && !ua.includes('mobile')) ||
+    (isAndroid && !hasMobileToken)
   ) {
     return 'tv';
   }
-  if (/mobi|android|touch|mini|windows ce|palm/i.test(ua)) {
+
+  if (hasMobileToken || (isAndroid && ua.includes('mobile'))) {
     return 'mobile';
   }
+
   return 'desktop';
-} 
+}


### PR DESCRIPTION
## Summary
- improve `detectDeviceType` so Android devices without `mobile` token are recognized as TV

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684728de2b2883298a7072803c9cfa54