### PR TITLE
Remove debug calendar output

### DIFF
--- a/src/components/FamilyPortal.tsx
+++ b/src/components/FamilyPortal.tsx
@@ -996,10 +996,6 @@ useEffect(() => {
   return (
     <div className={`min-h-screen bg-gray-100 dark:bg-gray-900 ${isRTL ? 'rtl' : 'ltr'}`}>
 
-    {/* DEBUG – remove later */}
-<pre style={{fontSize: '10px', background: '#0008', color: '#0f0', maxHeight: 120, overflow: 'auto'}}>
-  {JSON.stringify(calendarEvents /* or events */, null, 2)}
-</pre>
 
       {/* Header */}
       <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700 px-8 py-4">

--- a/src/components/FamilyPortal_bu.tsx
+++ b/src/components/FamilyPortal_bu.tsx
@@ -447,10 +447,6 @@ useEffect(() => {
   return (
     <div className={`min-h-screen bg-gray-100 dark:bg-gray-900 ${isRTL ? 'rtl' : 'ltr'}`}>
 
-    {/* DEBUG – remove later */}
-<pre style={{fontSize: '10px', background: '#0008', color: '#0f0', maxHeight: 120, overflow: 'auto'}}>
-  {JSON.stringify(calendarEvents /* or events */, null, 2)}
-</pre>
 
       {/* Header */}
       <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700 px-8 py-4">

--- a/src/components/FamilyPortal_prev.tsx
+++ b/src/components/FamilyPortal_prev.tsx
@@ -521,10 +521,6 @@ useEffect(() => {
   return (
     <div className={`min-h-screen bg-gray-100 dark:bg-gray-900 ${isRTL ? 'rtl' : 'ltr'}`}>
 
-    {/* DEBUG – remove later */}
-<pre style={{fontSize: '10px', background: '#0008', color: '#0f0', maxHeight: 120, overflow: 'auto'}}>
-  {JSON.stringify(calendarEvents /* or events */, null, 2)}
-</pre>
 
       {/* Header */}
       <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700 px-8 py-4">


### PR DESCRIPTION
## Summary
- delete calendar debug `<pre>` blocks from the FamilyPortal component and backups

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68486972ee648329bd25f86d7054d703