### PR TITLE
Persist Google token across sessions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,3 +12,11 @@ cp .env.example .env
 # 4. Run the development server
 npm run dev
 #    → open http://localhost:5173
+
+```
+
+## Persistent Google sign-in
+
+The dashboard now stores your Google access token in `localStorage` so you
+stay signed in even after restarting the TV or browser. To clear the token,
+use the "Log out" option in the settings menu.

--- a/src/components/FamilyPortal.tsx
+++ b/src/components/FamilyPortal.tsx
@@ -862,10 +862,10 @@ useEffect(() => {
     console.log('[Device Detection] Detected device type:', type);
   }, []);
 
-  // Revive Google auth state from session storage on load
+  // Revive Google auth state from local storage on load
   useEffect(() => {
-    const token = sessionStorage.getItem('google_token');
-    const exp = sessionStorage.getItem('google_token_exp');
+    const token = localStorage.getItem('google_token');
+    const exp = localStorage.getItem('google_token_exp');
     if (token && exp && Number(exp) > Date.now()) {
       setIsAuthenticated(true);
     }
@@ -912,8 +912,8 @@ useEffect(() => {
 
         if (data.status === 'linked') {
           if (data.token && data.expiresAt) {
-            sessionStorage.setItem('google_token', data.token);
-            sessionStorage.setItem('google_token_exp', String(data.expiresAt));
+            localStorage.setItem('google_token', data.token);
+            localStorage.setItem('google_token_exp', String(data.expiresAt));
             setIsAuthenticated(true);
           }
           setLinkStatus('linked');

--- a/src/services/googleAuth.ts
+++ b/src/services/googleAuth.ts
@@ -44,13 +44,13 @@ const TOKEN_KEY = 'google_token';
 const EXP_KEY   = 'google_token_exp';          // millis-since-epoch
 
 function saveToken(token: string, expiresAt: number) {
-  sessionStorage.setItem(TOKEN_KEY, token);
-  sessionStorage.setItem(EXP_KEY,  expiresAt.toString());
+  localStorage.setItem(TOKEN_KEY, token);
+  localStorage.setItem(EXP_KEY,  expiresAt.toString());
 }
 
 function loadToken(): { token: string; expiresAt: number } | null {
-  const t = sessionStorage.getItem(TOKEN_KEY);
-  const e = sessionStorage.getItem(EXP_KEY);
+  const t = localStorage.getItem(TOKEN_KEY);
+  const e = localStorage.getItem(EXP_KEY);
   return t && e ? { token: t, expiresAt: Number(e) } : null;
 }
 
@@ -66,7 +66,7 @@ let tokenClient: TokenClient | null = null;
 let cachedAccessToken = '';
 let tokenExpiresAt = 0;                         // millis
 
-// On page reload, revive prior token if still fresh
+// On page reload, revive prior token from local storage if still fresh
 const cached = loadToken();
 if (cached && cached.expiresAt > Date.now()) {
   cachedAccessToken = cached.token;
@@ -171,8 +171,8 @@ export function revokeGoogleToken() {
   window.google.accounts.oauth2.revoke(cachedAccessToken, () => {});
   cachedAccessToken = '';
   tokenExpiresAt = 0;
-  sessionStorage.removeItem(TOKEN_KEY);
-  sessionStorage.removeItem(EXP_KEY);
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(EXP_KEY);
 }
 
 // ––– helper –––


### PR DESCRIPTION
## Summary
- use localStorage instead of sessionStorage for Google auth token
- update token revival logic
- adjust linking flow to store token in localStorage
- document persistent sign-in in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68486bf952cc832995e8cce5d0e5dcbc