### PR TITLE
Add keep-alive pixel and subtle dashboard drift

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,10 @@
     <link rel="icon" href="src/assets/images/favicon.ico" />
   </head>
   <body class="min-h-screen bg-gray-100 dark:bg-gray-900">
-    <div id="root"></div>
+    <div id="dashboard">
+      <div id="root"></div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
-   <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
   </body>
 </html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,3 +9,10 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <App />
   </React.StrictMode>
 );
+
+document.addEventListener('visibilitychange', () => {
+  const el = document.getElementById('dashboard');
+  if (el) {
+    el.style.animationPlayState = document.hidden ? 'paused' : 'running';
+  }
+});

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -9,3 +9,39 @@ html.rtl {
 html.ltr {
   direction: ltr;
 }
+
+/* Invisible keep-alive pixel */
+body::after {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 1px;
+  height: 1px;
+  background: #000;
+  pointer-events: none;
+  animation: nudge 5s linear infinite;
+}
+
+@keyframes nudge {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  50% {
+    transform: translateX(1px);
+  }
+}
+
+#dashboard {
+  animation: drift 60s linear infinite alternate;
+}
+
+@keyframes drift {
+  from {
+    transform: translate(-3px, -3px);
+  }
+  to {
+    transform: translate(3px, 3px);
+  }
+}


### PR DESCRIPTION
## Summary
- add #dashboard wrapper for all content
- implement keep-alive pixel and drift animations in CSS
- pause drift animation when page is unfocused

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684c2466f6448329baae5c3c6c3d702c