### PR TITLE
Add keep-awake logic for background video

### DIFF
--- a/src/components/BackgroundVideo.tsx
+++ b/src/components/BackgroundVideo.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react';
 
 const INACTIVITY_TIMEOUT = 30000; // 30 seconds
+const KEEP_AWAKE_INTERVAL = 60000; // periodically bring video forward
+const KEEP_AWAKE_DURATION = 3000; // how long to keep it in front
 
 const BackgroundVideo: React.FC = () => {
   const [isFront, setIsFront] = useState(true);
@@ -22,6 +24,22 @@ const BackgroundVideo: React.FC = () => {
       events.forEach(evt => window.removeEventListener(evt, handleActivity));
       if (timerRef.current) {
         clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  // Periodically bring the video to the front to keep the screen awake
+  useEffect(() => {
+    let hideTimeout: number | undefined;
+    const interval = window.setInterval(() => {
+      setIsFront(true);
+      hideTimeout = window.setTimeout(() => setIsFront(false), KEEP_AWAKE_DURATION);
+    }, KEEP_AWAKE_INTERVAL);
+
+    return () => {
+      clearInterval(interval);
+      if (hideTimeout) {
+        clearTimeout(hideTimeout);
       }
     };
   }, []);


### PR DESCRIPTION
## Summary
- periodically raise the background video above the page content

## Testing
- `npm run lint` *(fails: couldn't find an eslint.config file)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68567cbd23bc8329b364c665193a30af