### PR TITLE
Fix background video path and add version info

### DIFF
--- a/src/components/BackgroundVideo.tsx
+++ b/src/components/BackgroundVideo.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import bgVideo from '../assets/videos/bg.mp4';
 
 const INACTIVITY_TIMEOUT = 30000; // 30 seconds
 const KEEP_AWAKE_INTERVAL = 60000; // periodically bring video forward
@@ -46,7 +47,7 @@ const BackgroundVideo: React.FC = () => {
 
   return (
     <video
-      src="/src/assets/videos/bg.mp4"
+      src={bgVideo}
       autoPlay
       loop
       muted

--- a/src/components/FamilyPortal.tsx
+++ b/src/components/FamilyPortal.tsx
@@ -17,6 +17,7 @@ import { getAccessToken } from '@services/auth';
 import defaultPhoto from '../assets/images/default.jpg';
 import { signOut as googleSignOut } from '@services/auth';
 import { detectDeviceType } from '@utils/device';
+import { APP_VERSION } from '@utils/version';
 
 const LOCAL_SETTINGS_KEY = 'family-portal-settings';
 
@@ -1783,6 +1784,9 @@ useEffect(() => {
               >
                 {t.saveSettings}
               </button>
+            </div>
+            <div className="mt-4 text-center text-gray-500 text-sm">
+              Version {APP_VERSION}
             </div>
           </div>
         </div>

--- a/src/types/version.d.ts
+++ b/src/types/version.d.ts
@@ -1,0 +1,2 @@
+declare const __APP_VERSION__: string;
+export {};

--- a/src/types/videos.d.ts
+++ b/src/types/videos.d.ts
@@ -1,0 +1,4 @@
+declare module '*.mp4' {
+  const src: string;
+  export default src;
+}

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,1 @@
+export const APP_VERSION = __APP_VERSION__;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
     "baseUrl": "./src",
     "paths": {
       "@components/*": ["components/*"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'node:path';
+import { version } from './package.json';
 
 export default defineConfig({
   plugins: [react()],
@@ -11,6 +12,9 @@ export default defineConfig({
       '@services': resolve(__dirname, 'src/services'),
       '@utils': resolve(__dirname, 'src/utils')
     }
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(version)
   },
   server: { port: 5173 }
 });


### PR DESCRIPTION
## Summary
- include app version via Vite constant
- show version in settings modal
- import background video asset instead of hardcoding path
- add type declarations for mp4 files
- expose app version through `@utils/version`

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6856813a91188329b82533126c8332d7