### PR TITLE
Fix link page overlay by removing background video

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,30 @@
 // src/App.tsx
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import FamilyPortal from '@components/FamilyPortal';
 import LinkDevice from '@components/LinkDevice'; // (we'll create this next)
 import PrivacyPolicy from '@components/PrivacyPolicy';
 import TermsOfService from '@components/TermsOfService';
 import BackgroundVideo from '@components/BackgroundVideo';
 
+const AppContent = () => {
+  const location = useLocation();
+  const showBackground = !location.pathname.startsWith('/link');
+  return (
+    <>
+      {showBackground && <BackgroundVideo />}
+      <Routes>
+        <Route path="/" element={<FamilyPortal />} />
+        <Route path="link" element={<LinkDevice />} />
+        <Route path="privacy" element={<PrivacyPolicy />} />
+        <Route path="terms" element={<TermsOfService />} />
+      </Routes>
+    </>
+  );
+};
+
 const App = () => (
   <BrowserRouter>
-    <BackgroundVideo />
-    <Routes>
-      <Route path="/" element={<FamilyPortal />} />
-      <Route path="link" element={<LinkDevice />} />
-      <Route path="privacy" element={<PrivacyPolicy />} />
-      <Route path="terms" element={<TermsOfService />} />
-    </Routes>
+    <AppContent />
   </BrowserRouter>
 );
 


### PR DESCRIPTION
## Summary
- render background video on all pages except the `/link` device sign-in page

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6856888e75c8832995ebb9fd65f5a9dc