### PR TITLE
Fix handleActivity closure in BackgroundVideo

### DIFF
--- a/src/components/BackgroundVideo.tsx
+++ b/src/components/BackgroundVideo.tsx
@@ -41,9 +41,6 @@ const BackgroundVideo: React.FC = () => {
       videoRef.current?.play().catch(() => {
         /* ignore autoplay errors */
       });
-    const handleActivity = () => {
-      setIsFront(false);
-      resetInactivityTimer();
     };
     const events = ['keydown', 'mousedown', 'touchstart', 'mousemove'];
     events.forEach(evt => window.addEventListener(evt, handleActivity));


### PR DESCRIPTION
## Summary
- remove the duplicate `handleActivity` definition in `BackgroundVideo`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_6856d6b6e2608329b021992c421afcd6