### PR TITLE
Add wake lock utility

### DIFF
--- a/src/components/BackgroundVideo.tsx
+++ b/src/components/BackgroundVideo.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 import bgVideo from '../assets/videos/bg.mp4';
+import useWakeLock from '@utils/wakeLock';
 
 const INACTIVITY_TIMEOUT = 30000; // ms of inactivity before showing video
 const FRONT_DURATION = 10000; // how long to keep video in front
 
 const BackgroundVideo: React.FC = () => {
+  useWakeLock();
   const [isFront, setIsFront] = useState(false);
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const inactivityTimer = useRef<number>();

--- a/src/utils/wakeLock.ts
+++ b/src/utils/wakeLock.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+const useWakeLock = () => {
+  useEffect(() => {
+    let sentinel: WakeLockSentinel | null = null;
+
+    const requestWakeLock = async () => {
+      try {
+        // navigator.wakeLock is not supported on all browsers
+        sentinel = await (navigator as any).wakeLock?.request('screen');
+      } catch {
+        // ignore wake lock errors
+      }
+    };
+
+    if ('wakeLock' in navigator) {
+      requestWakeLock();
+    }
+
+    return () => {
+      if (sentinel) {
+        sentinel.release().catch(() => {
+          /* ignore release errors */
+        });
+      }
+    };
+  }, []);
+};
+
+export default useWakeLock;


### PR DESCRIPTION
## Summary
- add `useWakeLock` hook to keep screen awake
- keep display awake in `BackgroundVideo`

## Testing
- `npm run lint` *(fails: couldn't find ESLint configuration)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6860113bba6883299001f507dec78cf8