### PR TITLE
Remove logs and fix date overrides

### DIFF
--- a/src/components/FamilyPortal.tsx
+++ b/src/components/FamilyPortal.tsx
@@ -255,11 +255,8 @@ const FamilyPortal = () => {
 */
 
 useEffect(() => {
-    console.log('🚀 useEffect fired - about to call fetchCalendarEvents');
     fetchCalendarEvents()
       .then((events) => {
-        console.log('✔ got', events.length, 'events from fetch');
-        console.log('🔄 updating with', events.length, 'items');
         setCalendarEvents(events);
       })
       .catch(console.error);
@@ -267,15 +264,12 @@ useEffect(() => {
     // Fetch weather data
     fetchWeatherData(settings.location)
       .then((data) => {
-        console.log('🌤️ Got weather data:', data);
         setWeatherData(data);
       })
       .catch((error) => {
         console.error('Error fetching weather:', error);
         // Load mock data if fetch fails
-        console.log('Loading mock weather data as fallback');
         const mockData = getMockWeatherData();
-        console.log('Setting mock weather data:', mockData);
         setWeatherData(mockData);
       });
   
@@ -288,7 +282,6 @@ useEffect(() => {
 
 // Add a separate useEffect to monitor weather data changes
 useEffect(() => {
-  console.log('Weather data changed:', weatherData);
 }, [weatherData]);
 
   const loadMockData = () => {
@@ -296,7 +289,6 @@ useEffect(() => {
     today.setFullYear(2025, 5, 1); // Set to June 1st, 2025
     today.setHours(12, 0, 0, 0); // Set to noon for consistent comparison
     
-    console.log('Setting up mock events with base date:', today.toISOString());
     
     const mockEvents: CalendarEvent[] = [
       {
@@ -341,7 +333,6 @@ useEffect(() => {
       }
     ];
     
-    console.log('Created mock events:', mockEvents.map(e => ({
       title: e.title,
       start: e.start.toISOString(),
       end: e.end.toISOString()
@@ -587,7 +578,6 @@ useEffect(() => {
     today.setFullYear(2025, 5, 1); // Set to June 1st, 2025
     today.setHours(12, 0, 0, 0); // Set to noon for consistent comparison
     
-    console.log('Setting mock weather data with today:', today.toISOString());
     
     // Generate hourly forecast for the next 24 hours
     const hourlyForecast = Array.from({ length: 24 }, (_, i) => {
@@ -886,7 +876,6 @@ useEffect(() => {
   useEffect(() => {
     const type = detectDeviceType();
     setDeviceType(type);
-    console.log('[Device Detection] Detected device type:', type);
   }, []);
 
   // Revive Google auth state from local storage on load

--- a/src/services/calendar.ts
+++ b/src/services/calendar.ts
@@ -33,14 +33,6 @@ export async function fetchCalendarEvents(): Promise<CalendarEvent[]> {
   const rangeEnd = new Date(rangeStart);
   rangeEnd.setDate(rangeEnd.getDate() + days);
 
-  console.log('Fetching 2-week window:', {
-    start: rangeStart.toLocaleString(),
-    end: rangeEnd.toLocaleString()
-  });
-  console.log('UTC date range:', {
-    start: rangeStart.toISOString(),
-    end: rangeEnd.toISOString()
-  });
 
   // Fetch Google Calendar color palette
   const colorRes = await fetch('https://www.googleapis.com/calendar/v3/colors', {
@@ -59,7 +51,6 @@ export async function fetchCalendarEvents(): Promise<CalendarEvent[]> {
   if (!res.ok) throw new Error(await res.text());
   const data = await res.json();
 
-  console.log('🗓️ Google Calendar items:', data.items);
 
   const items: any[] = data.items ?? [];
 

--- a/src/services/googleAuth.ts
+++ b/src/services/googleAuth.ts
@@ -87,7 +87,6 @@ export async function signInWithGoogle(): Promise<string> {
 
   if (!tokenClient) {
     const currentOrigin = window.location.origin;
-    console.log('Current origin:', currentOrigin); // Debug log
 
     // @ts-ignore
     tokenClient = window.google.accounts.oauth2.initTokenClient({
@@ -178,7 +177,6 @@ export function revokeGoogleToken() {
 // ––– helper –––
 function ensureGisLoaded(): Promise<void> {
     // TODO: remove
-    console.log('GIS token ok', cachedAccessToken.slice(0, 10));
   
     // @ts-ignore
   if (window.google?.accounts?.oauth2) return Promise.resolve();

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -15,10 +15,7 @@ function getWeatherIconUrl(iconCode: string): string {
 function groupForecastsByDay(forecasts: any[], timezoneOffset: number) {
   const dailyForecasts = new Map();
   const baseDate = new Date();
-  baseDate.setFullYear(2025, 5, 1); // Set to June 1st, 2025
   baseDate.setHours(12, 0, 0, 0); // Set to noon for consistent comparison
-  
-  console.log('Processing forecasts:', forecasts);
   
   forecasts.forEach(item => {
     const date = new Date(baseDate);
@@ -40,19 +37,11 @@ function groupForecastsByDay(forecasts: any[], timezoneOffset: number) {
     dayData.temps.push(item.main.temp);
     dayData.conditions.push(item.weather[0].description);
     dayData.weatherIds.push(item.weather[0].id);
-    
-    /*console.log('Weather data for', dayKey, ':', {
-      temp: item.main.temp,
-      condition: item.weather[0].description,
-      id: item.weather[0].id
-    });*/
   });
   
   const result = Array.from(dailyForecasts.values()).map(day => {
     const weatherId = day.weatherIds[Math.floor(day.weatherIds.length / 2)];
-    // console.log('Converting weather ID', weatherId, 'to icon');
     const icon = getWeatherIcon(weatherId);
-    // console.log('Resulting icon:', icon);
     
     return {
       time: day.date.toISOString(),
@@ -62,13 +51,11 @@ function groupForecastsByDay(forecasts: any[], timezoneOffset: number) {
     };
   });
   
-  console.log('Final daily forecast:', result);
   return result;
 }
 
 export async function fetchWeatherData(location: { city: string; country: string }): Promise<WeatherData> {
   if (!API_KEY) {
-    console.log('No API key found, returning mock data');
     return getMockWeatherData();
   }
 
@@ -84,7 +71,6 @@ export async function fetchWeatherData(location: { city: string; country: string
     }
     
     const currentData = await currentResponse.json();
-    console.log('Current weather data:', currentData);
 
     // Fetch 5-day forecast with 3-hour intervals
     const forecastResponse = await fetch(
@@ -97,7 +83,6 @@ export async function fetchWeatherData(location: { city: string; country: string
     }
     
     const forecastData = await forecastResponse.json();
-    console.log('Forecast data:', forecastData);
 
     // Get sunrise and sunset times in local timezone
     const timezoneOffset = currentData.timezone * 1000; // Convert to milliseconds
@@ -126,11 +111,9 @@ export async function fetchWeatherData(location: { city: string; country: string
     // Get current time
     const now = new Date();
     const currentHour = now.getHours();
-    console.log('Current hour:', currentHour);
 
     // Find the last standard 3-hour interval
     const lastInterval = Math.floor(currentHour / 3) * 3;
-    console.log('Last 3-hour interval:', lastInterval);
 
     // Generate hourly data by interpolating between 3-hour intervals
     const interpolatedForecast = [];
@@ -215,7 +198,6 @@ export async function fetchWeatherData(location: { city: string; country: string
       return hour % 3 === 0;
     });
 
-    console.log('Final interpolated forecast:', interpolatedForecast.map(f => ({
       time: new Date(f.time).toLocaleTimeString(),
       temp: f.temperature
     })));
@@ -242,11 +224,9 @@ export async function fetchWeatherData(location: { city: string; country: string
 // Helper function to get mock weather data
 function getMockWeatherData(): WeatherData {
   const today = new Date();
-  today.setFullYear(2025, 5, 1); // Set to June 1st, 2025
   const currentHour = today.getHours();
   today.setHours(currentHour, 0, 0, 0); // Set to current hour
   
-  console.log('Mock weather data - base date:', today.toISOString());
   
   // Generate 24 hours of forecast data starting from current hour
   const forecast = Array.from({ length: 24 }, (_, i) => {
@@ -283,7 +263,6 @@ function getMockWeatherData(): WeatherData {
 
 // Helper function to convert OpenWeather condition codes to emoji icons
 function getWeatherIcon(code: number): string {
-  // console.log('Getting icon for code:', code);
   
   // Handle string codes (just in case)
   if (typeof code === 'string') {


### PR DESCRIPTION
## Summary
- purge `console.log` statements from modules
- use real dates in weather service instead of a 2025 override

## Testing
- `npm run lint` *(fails: couldn't find ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68601e60f5688329a4d2739c089c684c