### PR TITLE
Improve wake lock handling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,3 +20,10 @@ npm run dev
 The dashboard now stores your Google access token in `localStorage` so you
 stay signed in even after restarting the TV or browser. To clear the token,
 use the "Log out" option in the settings menu.
+
+## Preventing screen sleep
+
+The dashboard requests a screen wake lock so the TV doesn't dim or show a
+screen saver while it's running. If the browser releases the lock or the page
+regains focus after being hidden, the dashboard automatically re-acquires the
+lock to keep the screen awake.

--- a/src/utils/wakeLock.ts
+++ b/src/utils/wakeLock.ts
@@ -8,21 +8,31 @@ const useWakeLock = () => {
       try {
         // navigator.wakeLock is not supported on all browsers
         sentinel = await (navigator as any).wakeLock?.request('screen');
+        sentinel?.addEventListener('release', requestWakeLock);
       } catch {
         // ignore wake lock errors
       }
     };
 
+    const handleVisibility = () => {
+      if (!document.hidden) {
+        requestWakeLock();
+      }
+    };
+
     if ('wakeLock' in navigator) {
       requestWakeLock();
+      document.addEventListener('visibilitychange', handleVisibility);
     }
 
     return () => {
       if (sentinel) {
+        sentinel.removeEventListener('release', requestWakeLock);
         sentinel.release().catch(() => {
           /* ignore release errors */
         });
       }
+      document.removeEventListener('visibilitychange', handleVisibility);
     };
   }, []);
 };


### PR DESCRIPTION
## Summary
- reacquire wake lock when the page becomes visible or when the lock is released
- document screen wake lock behaviour

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68603557e69883299cb46283aaa8a2d9