### PR TITLE
Fix wake lock and background video

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,8 +5,10 @@ import LinkDevice from '@components/LinkDevice'; // (we'll create this next)
 import PrivacyPolicy from '@components/PrivacyPolicy';
 import TermsOfService from '@components/TermsOfService';
 import BackgroundVideo from '@components/BackgroundVideo';
+import useWakeLock from '@utils/wakeLock';
 
 const AppContent = () => {
+  useWakeLock();
   const location = useLocation();
   const showBackground = !location.pathname.startsWith('/link');
   return (


### PR DESCRIPTION
## Summary
- keep the screen awake on every page
- retry wake lock when users interact with the page

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870133af5ac8329a1ff0b952dac2497